### PR TITLE
improvement: test-lint enforces snake case

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,7 @@
 [flake8]
-ignore = E203, E266, E501, W503
+ignore = E501,W503
 max-line-length = 80
 max-complexity = 18
-select = B,C,E,F,W,T4,B9
 exclude =
     __pycache__,
     .cache,

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,17 @@ DOCKER_IMAGE?=opentutor_classifier
 # virtualenv used for pytest
 VENV=.venv
 $(VENV):
-	$(MAKE) venv-create
+	$(MAKE) $(VENV)-update
+
+.PHONY: $(VENV)-update
+$(VENV)-update: virtualenv-installed
+	[ -d $(VENV) ] || virtualenv -p python3.8 $(VENV)
+	$(VENV)/bin/pip install --upgrade pip
+	$(VENV)/bin/pip install -r ./requirements.test.txt
+	$(VENV)/bin/python3.8 -m nltk.downloader punkt
+	$(VENV)/bin/python3.8 -m nltk.downloader wordnet
+	$(VENV)/bin/python3.8 -m nltk.downloader averaged_perceptron_tagger
+	$(VENV)/bin/python3.8 -m nltk.downloader stopwords
 
 .PHONY clean:
 clean:
@@ -31,7 +41,7 @@ docker-test-train:
 		
 .PHONY: format
 format: $(VENV)
-	$(VENV)/bin/black opentutor_classifier tests
+	$(VENV)/bin/black .
 
 PHONY: test
 test: $(VENV)
@@ -42,7 +52,7 @@ test-all: test-format test-lint test-types test
 
 .PHONY: test-format
 test-format: $(VENV)
-	$(VENV)/bin/black --check opentutor_classifier tests
+	$(VENV)/bin/black --check .
 
 .PHONY: test-lint
 test-lint: $(VENV)
@@ -55,16 +65,6 @@ test-types: $(VENV)
 .PHONY: update-deps
 update-deps: $(VENV)
 	. $(VENV)/bin/activate && pip-upgrade requirements*
-
-.PHONY: venv-create
-venv-create: virtualenv-installed
-	[ -d $(VENV) ] || virtualenv -p python3.8 $(VENV)
-	$(VENV)/bin/pip install --upgrade pip
-	$(VENV)/bin/pip install -r ./requirements.test.txt
-	$(VENV)/bin/python3.8 -m nltk.downloader punkt
-	$(VENV)/bin/python3.8 -m nltk.downloader wordnet
-	$(VENV)/bin/python3.8 -m nltk.downloader averaged_perceptron_tagger
-	$(VENV)/bin/python3.8 -m nltk.downloader stopwords
 
 virtualenv-installed:
 	tools/virtualenv_ensure_installed.sh

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,10 +1,12 @@
 -r requirements.txt
 black==19.3b0
-flake8==3.7.7
+flake8==3.8.3
 mypy==v0.761
-pytest==5.2.0
-pytest-mock==1.11.0
-pytest-cov==2.7.1
+pep8-naming==0.10.0
+pip-upgrader
+pytest==5.4.3
+pytest-mock==3.1.1
+pytest-cov==2.10.0
 pytest-env==0.6.2
-pytest-flask==0.15.0
-pytest-sugar==0.9.2
+pytest-flask==1.0.0
+pytest-sugar==0.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pandas==1.0.4
 nltk==3.5
 scikit-learn==0.23.1
 # FIXME: Locking werkzeug until the resolution of pallets/werkzeug#1714
-werkzeug==0.16.1
+werkzeug==1.0.1


### PR DESCRIPTION
This PR adds rules so that `make test-lint` will fail if python variables are not snake case.

So the `test-lint` check is currently failing. If you merge this back to your branch, then you can run `make test-lint` locally to see what needs to be fixed