### PR TITLE
fixes: ci tests require git lfs and pull for word2vec model

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,8 +67,6 @@ jobs:
       - run:
           command: |
             echo "Digest is: $(</tmp/digest.txt)"
-      - *git-lfs-install
-      - *git-lfs-pull
   test-format:
     executor: python
     steps:
@@ -76,8 +74,6 @@ jobs:
       - run:
           name: Test format
           command: make test-format
-      - *git-lfs-install
-      - *git-lfs-pull
   test-lint:
     executor: python
     steps:
@@ -85,8 +81,6 @@ jobs:
       - run:
           name: Test lint
           command: make test-lint
-      - *git-lfs-install
-      - *git-lfs-pull
   test-types:
     executor: python
     steps:
@@ -94,12 +88,12 @@ jobs:
       - run:
           name: Test types
           command: make test-types
-      - *git-lfs-install
-      - *git-lfs-pull
   test:
     executor: python
     steps:
+      - *git-lfs-install
       - checkout
+      - *git-lfs-pull
       - run:
           name: install required packages
           command: sudo apt-get install libsndfile1
@@ -108,8 +102,6 @@ jobs:
       - run:
           name: Run tests
           command: make test
-      - *git-lfs-install
-      - *git-lfs-pull
 workflows:
   test-build-publish:
     jobs:


### PR DESCRIPTION
So you *almost* had this one in that you figured out the problem was w git lfs etc. 

I added the changes to make it fully work. Hopefully tmrw less crazy day and we can move forward w the deployment